### PR TITLE
add info about eclipse/papyrus Neon compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ The Base Variability Resolution (BVR) is a language to engineer software product
 See http://modelbased.net/tools/bvr-tool/
 
 ### Source Installation Requirements
-1. Eclipse Modeling Tools - Kepler SR2 revision
-2. Papyrus UML v0.10.1 for third-party integration plugins
+1. Eclipse Modeling Tools - BVR was developed on eclipse Kepler SR2, but also seems to work on eclipse Neon
+2. Papyrus UML v0.10.1 for third-party integration plugins.  BVR seems to work fine using the Papyrus Neon release (2.0.3)
 3. Java 8


### PR DESCRIPTION
BVR seems indeed to work fine on eclipse/papyrus Neon (see issue #14 ).  This small patch updates README.md